### PR TITLE
Add files section to NPM package descriptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,11 @@
     "viewport",
     "inview",
     "jquery"
+  ],
+  "files": [
+    "*.md",
+    "LICENSE",
+    "src",
+    "dist"
   ]
 }


### PR DESCRIPTION
Required to identify production files and excl. dev-related assets